### PR TITLE
Lowercasing Colab link

### DIFF
--- a/0_4_accessing_an_api.ipynb
+++ b/0_4_accessing_an_api.ipynb
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MJMortensonWarwick/CND/blob/main/0_4_Accessing_an_API.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/MJMortensonWarwick/CND/blob/main/0_4_accessing_an_api.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
The colab link used the old file name that included uppercase letters. This meant the button to view the file in colab failed.  Using the lowercase URL allows the file to be opened